### PR TITLE
Fixed issue CLI-25

### DIFF
--- a/src/main/scss/style/cards.scss
+++ b/src/main/scss/style/cards.scss
@@ -940,6 +940,7 @@ div#homePage {
                                         &:disabled {
                                             background-color: #5a5;
                                             &:hover {
+                                                cursor: default;
                                                 background-color: #5a5;
                                             }
                                         }


### PR DESCRIPTION
Disabled save button: Edit card: when the card has no changes, the "save" button is disabled, but the cursor still show the "pointer" mode when hovering. Also, the two tones of green for enabled/disabled are very close and not easy to spot.